### PR TITLE
Makese this truly autonomous.

### DIFF
--- a/SolidityContracts/AP_Factory/autonomousProposalFactory.sol
+++ b/SolidityContracts/AP_Factory/autonomousProposalFactory.sol
@@ -151,27 +151,4 @@ contract CrowdProposalFactory {
         CrowdProposal proposal = new CrowdProposal(targets, values, signatures, calldatas, description, uni, governor);
         emit CrowdProposalCreated(address(proposal), targets, values, signatures, calldatas, description);
     }
-
-    /**
-    * @notice Create a new crowd proposal
-    * @notice Call `uni.approve(factory_address, uniStakeAmount)` before calling this method
-    * @param targets The ordered list of target addresses for calls to be made
-    * @param values The ordered list of values (i.e. msg.value) to be passed to the calls to be made
-    * @param signatures The ordered list of function signatures to be called
-    * @param calldatas The ordered list of calldata to be passed to each call
-    * @param description The block at which voting begins: holders must delegate their votes prior to this block
-    */
-    function createCrowdProposal(
-        address[] memory targets,
-        uint[] memory values,
-        string[] memory signatures,
-        bytes[] memory calldatas,
-        string memory description
-    ) external {
-        CrowdProposal proposal = new CrowdProposal(msg.sender, targets, values, signatures, calldatas, description, uni, governor);
-        emit CrowdProposalCreated(address(proposal), msg.sender, targets, values, signatures, calldatas, description);
-
-        // Stake UNI and force proposal to delegate votes to itself
-        IUni(uni).transferFrom(msg.sender, address(proposal), uniStakeAmount);
-    }
 }

--- a/SolidityContracts/AP_Factory/autonomousProposalFactory.sol
+++ b/SolidityContracts/AP_Factory/autonomousProposalFactory.sol
@@ -18,9 +18,6 @@ interface IGovernorAlpha {
 }
 
 contract CrowdProposal {
-    /// @notice The crowd proposal author
-    address payable public immutable author;
-
     /// @notice Governance proposal data
     address[] public targets;
     uint[] public values;
@@ -28,8 +25,6 @@ contract CrowdProposal {
     bytes[] public calldatas;
     string public description;
 
-    /// @notice UNI token contract address
-    address public immutable uni;
     /// @notice Uniswap protocol `GovernorAlpha` contract address
     address public immutable governor;
 
@@ -39,15 +34,14 @@ contract CrowdProposal {
     bool public terminated;
 
     /// @notice An event emitted when the governance proposal is created
-    event CrowdProposalProposed(address indexed proposal, address indexed author, uint proposalId);
-    /// @notice An event emitted when the crowd proposal is terminated
-    event CrowdProposalTerminated(address indexed proposal, address indexed author);
-    /// @notice An event emitted when delegated votes are transfered to the governance proposal
-    event CrowdProposalVoted(address indexed proposal, uint proposalId);
+    event CrowdProposalProposed(address indexed proposal, uint proposalId);
+    /// @notice An event emitted when a yes vote is cast
+    event CrowdProposalVotedYes(address indexed proposal, uint proposalId);
+    /// @notice An event emitted when a no vote is cast
+    event CrowdProposalVotedNo(address indexed proposal, uint proposalId);
 
     /**
     * @notice Construct crowd proposal
-    * @param author_ The crowd proposal author
     * @param targets_ The ordered list of target addresses for calls to be made
     * @param values_ The ordered list of values (i.e. msg.value) to be passed to the calls to be made
     * @param signatures_ The ordered list of function signatures to be called
@@ -56,65 +50,63 @@ contract CrowdProposal {
     * @param uni_ `UNI` token contract address
     * @param governor_ Uniswap protocol `GovernorAlpha` contract address
     */
-    constructor(address payable author_,
-                address[] memory targets_,
-                uint[] memory values_,
-                string[] memory signatures_,
-                bytes[] memory calldatas_,
-                string memory description_,
-                address uni_,
-                address governor_) public {
-                    author = author_;
+    constructor(
+        address[] memory targets_,
+        uint[] memory values_,
+        string[] memory signatures_,
+        bytes[] memory calldatas_,
+        string memory description_,
+        address uni_,
+        address governor_
+    ) public {
+        // Save proposal data
+        targets = targets_;
+        values = values_;
+        signatures = signatures_;
+        calldatas = calldatas_;
+        description = description_;
 
-                    // Save proposal data
-                    targets = targets_;
-                    values = values_;
-                    signatures = signatures_;
-                    calldatas = calldatas_;
-                    description = description_;
+        // Save Uniswap contracts data
+        governor = governor_;
 
-                    // Save Uniswap contracts data
-                    uni = uni_;
-                    governor = governor_;
+        terminated = false;
 
-                    terminated = false;
+        // Delegate votes to the crowd proposal
+        IUni(uni_).delegate(address(this));
+    }
 
-                    // Delegate votes to the crowd proposal
-                    IUni(uni_).delegate(address(this));
-                }
+    /// @notice Create governance proposal
+    function propose(
+    ) external returns (uint) {
+        require(govProposalId == 0, 'CrowdProposal::propose: gov proposal already exists');
+        require(!terminated, 'CrowdProposal::propose: proposal has been terminated');
 
-                /// @notice Create governance proposal
-                function propose() external returns (uint) {
-                    require(govProposalId == 0, 'CrowdProposal::propose: gov proposal already exists');
-                    require(!terminated, 'CrowdProposal::propose: proposal has been terminated');
+        // Create governance proposal and save proposal id
+        govProposalId = IGovernorAlpha(governor).propose(targets, values, signatures, calldatas, description);
+        emit CrowdProposalProposed(govProposalId);
 
-                    // Create governance proposal and save proposal id
-                    govProposalId = IGovernorAlpha(governor).propose(targets, values, signatures, calldatas, description);
-                    emit CrowdProposalProposed(address(this), author, govProposalId);
+        voteYes();
 
-                    return govProposalId;
-                }
+        return govProposalId;
+    }
 
-                /// @notice Terminate the crowd proposal, send back staked UNI tokens
-                function terminate() external {
-                    require(msg.sender == author, 'CrowdProposal::terminate: only author can terminate');
-                    require(!terminated, 'CrowdProposal::terminate: proposal has been already terminated');
+    /// @notice Vote yes for the governance proposal with all delegated votes
+    function voteYes(
+    ) public {
+        require(govProposalId > 0, 'CrowdProposal::voteYes: gov proposal has not been created yet');
+        IGovernorAlpha(governor).castVote(govProposalId, true);
 
-                    terminated = true;
+        emit CrowdProposalVotedYes(govProposalId);
+    }
 
-                    // Transfer staked UNI tokens from the crowd proposal contract back to the author
-                    IUni(uni).transfer(author, IUni(uni).balanceOf(address(this)));
-
-                    emit CrowdProposalTerminated(address(this), author);
-                }
-
-                /// @notice Vote for the governance proposal with all delegated votes
-                function vote() external {
-                    require(govProposalId > 0, 'CrowdProposal::vote: gov proposal has not been created yet');
-                    IGovernorAlpha(governor).castVote(govProposalId, true);
-
-                    emit CrowdProposalVoted(address(this), govProposalId);
-                }
+    /// @notice Vote no for any other governance proposal with all delegated votes
+    function voteNo(
+        uint256 proposalId_
+    ) external {
+        require(proposalId_ != govProposalId, 'CrowdProposal::voteNo: cannot vote no on this proposal');
+        IGovernorAlpha(governor).castVote(proposalId_, false);
+        emit CrowdProposalVotedNo(proposalId_);
+    }
 }
 
 
@@ -123,45 +115,41 @@ contract CrowdProposalFactory {
     address public immutable uni;
     /// @notice Uniswap protocol `GovernorAlpha` contract address
     address public immutable governor;
-    /// @notice Minimum uni tokens required to create a crowd proposal
-    uint public immutable uniStakeAmount;
 
     /// @notice An event emitted when a crowd proposal is created
-    event CrowdProposalCreated(address indexed proposal, address indexed author, address[] targets, uint[] values, string[] signatures, bytes[] calldatas, string description);
+    event CrowdProposalCreated(address indexed proposal, address[] targets, uint[] values, string[] signatures, bytes[] calldatas, string description);
 
     /**
     * @notice Construct a proposal factory for crowd proposals
     * @param uni_ `UNI` token contract address
     * @param governor_ Uniswap protocol `GovernorAlpha` contract address
     * @param uniStakeAmount_ The minimum amount of uni tokes required for creation of a crowd proposal
-        */
-    constructor(address uni_,
-                address governor_,
-                uint uniStakeAmount_) public {
-                    uni = uni_;
-                    governor = governor_;
-                    uniStakeAmount = uniStakeAmount_;
-                }
+    */
+    constructor(
+        address uni_,
+        address governor_
+    ) public {
+        uni = uni_;
+        governor = governor_;
+    }
 
-                /**
-                * @notice Create a new crowd proposal
-                * @notice Call `uni.approve(factory_address, uniStakeAmount)` before calling this method
-                * @param targets The ordered list of target addresses for calls to be made
-                * @param values The ordered list of values (i.e. msg.value) to be passed to the calls to be made
-                * @param signatures The ordered list of function signatures to be called
-                * @param calldatas The ordered list of calldata to be passed to each call
-                * @param description The block at which voting begins: holders must delegate their votes prior to this block
-                */
-                function createCrowdProposal(address[] memory targets,
-                                             uint[] memory values,
-                                             string[] memory signatures,
-                                             bytes[] memory calldatas,
-                                             string memory description) external {
-                                                 CrowdProposal proposal = new CrowdProposal(msg.sender, targets, values, signatures, calldatas, description, uni, governor);
-                                                 emit CrowdProposalCreated(address(proposal), msg.sender, targets, values, signatures, calldatas, description);
-
-                                                 // Stake UNI and force proposal to delegate votes to itself
-                                                 IUni(uni).transferFrom(msg.sender, address(proposal), uniStakeAmount);
-                                             }
+    /**
+    * @notice Create a new crowd proposal
+    * @param targets The ordered list of target addresses for calls to be made
+    * @param values The ordered list of values (i.e. msg.value) to be passed to the calls to be made
+    * @param signatures The ordered list of function signatures to be called
+    * @param calldatas The ordered list of calldata to be passed to each call
+    * @param description The block at which voting begins: holders must delegate their votes prior to this block
+    */
+    function createCrowdProposal(
+        address[] memory targets,
+        uint[] memory values,
+        string[] memory signatures,
+        bytes[] memory calldatas,
+        string memory description
+    ) external {
+        CrowdProposal proposal = new CrowdProposal(targets, values, signatures, calldatas, description, uni, governor);
+        emit CrowdProposalCreated(address(proposal), targets, values, signatures, calldatas, description);
+    }
 
 }


### PR DESCRIPTION
Prior to this change, contracts created by this weren't actually autonomous.  They had an author who functioned as an owner and had limited power over the contract.  Specifically, they had the ability to terminate the proposal.  This meant that they had the power to pull the proposal at up to the last minute, or after the proposal was proposed but before it was voted on, causing disruption within the community.

With this change, the contracts generated by this factory are now truly autonomous as once they are created they cannot be mutated at all.

I have also added in the functionality to have these proposals vote no on everything *except* the proposal from this contract.  This makes it so people don't have to worry about their delegated UNI abstaining from an important proposal that is launched non-autonomously.

### Recommended future additions:
Make it so there is a delay of 7 days between when the proposal reaches 10M UNI delegated and when it files the proposal and votes.  This will give ample time for people to prepare their UNI for voting on the proposal.  This is particularly important if there are multiple autonomous proposals that a person wants to support, they shouldn't have to worry about one of them going through as a surprise while they are delegated to another.